### PR TITLE
fix(sample): update IotMapManager import to use the npm package

### DIFF
--- a/src/map/map.component.ts
+++ b/src/map/map.component.ts
@@ -3,7 +3,7 @@ import {
   AfterViewInit
 } from '@angular/core';
 
-import { IotMapManager } from '../iotMapManager/iotmapmanager';
+import { IotMapManager } from 'iotmapmanager/iotMapManager';
 
 @Component({
   selector: 'map-component',


### PR DESCRIPTION
The documentation says:

> Angular sample of use is given in map/map.components.ts (and not included by npm) to display/refresh map elements, using javascript IoTMapManager class methods

Now that the library is installable from npm, the import should be updated.