### PR TITLE
Remove loading of 'iotmap-icon.css' and loads images as assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "ng build",
     "lint": "eslint src\\iotMapManager\\**\\*.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -s ./src/iotMapManager/img:/assets/img -p 6006",
     "build-storybook": "build-storybook"
   },
   "repository": {

--- a/src/stories/Test.stories.css
+++ b/src/stories/Test.stories.css
@@ -1,2 +1,1 @@
 @import "../iotMapManager/iot-map-manager.css";
-@import "assets/fonts/iotmap-icons.css";


### PR DESCRIPTION
`master` branch currently thows the following error after running `npm run storybook`:

```
ERROR in ./src/stories/Test.stories.css (./node_modules/css-loader/dist/cjs.js??ref--12-1!./node_modules/postcss-loader/src??postcss!./src/stories/Test.stories.css)
Module not found: Error: Can't resolve './assets/fonts/iotmap-icons.css' in '/Users/ju/IOT-Map-Component/src/stories'
 @ ./src/stories/Test.stories.css (./node_modules/css-loader/dist/cjs.js??ref--12-1!./node_modules/postcss-loader/src??postcss!./src/stories/Test.stories.css) 4:40-193
 @ ./src/stories/Test.stories.css
 @ ./src/stories/Test.stories.ts
 @ ./src sync ^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(js|jsx|ts|tsx))$
 @ ./.storybook/generated-stories-entry.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/storybook-init-framework-entry.js ./node_modules/@storybook/addon-docs/dist/frameworks/common/config.js-generated-other-entry.js ./node_modules/@storybook/addon-docs/dist/frameworks/html/config.js-generated-other-entry.js ./node_modules/@storybook/addon-links/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-actions/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-actions/dist/preset/addArgs.js-generated-other-entry.js ./node_modules/@storybook/addon-backgrounds/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-backgrounds/dist/preset/addParameter.js-generated-other-entry.js ./node_modules/@storybook/addon-knobs/dist/preset/addDecorator.js-generated-other-entry.js ./.storybook/preview.js-generated-config-entry.js ./.storybook/generated-stories-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined
```

This PR remove the import of `iotmap-icon.css` which doesn't exist anymore.

I benefit from this PR to load the images as assets to display in Storybook the shadows (among others images).

Note: This will probably need some actions for the `build-storybook` part if Storybook must be built statically