### PR TITLE
Improve docs workflow and make it work with gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,11 @@ jobs:
         with:
           node-version: '12.x'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build Storybook
-        run: npm run build-storybook && mv storybook-static docs
-        
-    
+        run: npm run build-storybook
+      - name: Deploy Storybook
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          npm run deploy-storybook

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ testem.log
 .DS_Store
 Thumbs.db
 /src/assets/icons/
-
-# Storybook
-docs

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/iotMapManager/**/*.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -s ./src/iotMapManager/img:/assets/img -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook -o ./docs && mkdir -p docs/assets/img && cp src/iotMapManager/img/* docs/assets/img/",
+    "deploy-storybook": "git add docs && git commit -m 'chore(storybook): deploy' --allow-empty && git subtree split --branch gh-pages --prefix docs && git push origin gh-pages -f && echo 'Storybook successfully deployed'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://github.com/Orange-OpenSource/IOT-Map-Component/pull/15 does not work as expected. This PR will rather use a `gh-pages` branch to publish the built Storybook static website.

Some reference about the system used: https://github.com/ffoodd/a11y.css/blob/master/package.json#L26

- [x] Take into account https://github.com/Orange-OpenSource/IOT-Map-Component/pull/15/files#r581071877
- [x] Take into account https://github.com/Orange-OpenSource/IOT-Map-Component/pull/15/files#r581070749
- [x] Remove `docs` from .gitignore to be able to push it to the `gh-pages` branch
- [x] Create `gh-pages` branch
- [x] Modify GitHub settings to create GitHub pages from `gh-pages`
- [x] Modify the workflow to publish `docs` directory into the `gh-pages` via `npm run deploy-storybook`

Storybook must be deployed to https://orange-opensource.github.io/IOT-Map-Component/