### PR TITLE
Storybook: fix CSS import to avoid CaseSensitivePathsPlugin error

### DIFF
--- a/src/stories/Test.stories.css
+++ b/src/stories/Test.stories.css
@@ -1,1 +1,1 @@
-@import '~iotmapmanager/iot-map-manager.css';
+@import '~iotMapManager/iot-map-manager.css';


### PR DESCRIPTION
This PR is a proposal to be able to run Storybook locally. Hope it will not affect GitHub Pages.

```
$ npm run storybook

ERROR in ./src/stories/Test.stories.css (./node_modules/css-loader/dist/cjs.js??ref--12-1!./node_modules/postcss-loader/src??postcss!./src/stories/Test.stories.css)
Module not found: Error: [CaseSensitivePathsPlugin] `/Users/ju/IOT-Map-Component/src/iotmapmanager/iot-map-manager.css` does not match the corresponding path on disk `iotMapManager`.
 @ ./src/stories/Test.stories.css (./node_modules/css-loader/dist/cjs.js??ref--12-1!./node_modules/postcss-loader/src??postcss!./src/stories/Test.stories.css) 3:40-195
 @ ./src/stories/Test.stories.css
 @ ./src/stories/Test.stories.ts
 @ ./src sync ^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(js|jsx|ts|tsx))$
 @ ./.storybook/generated-stories-entry.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/storybook-init-framework-entry.js ./node_modules/@storybook/addon-docs/dist/frameworks/common/config.js-generated-other-entry.js ./node_modules/@storybook/addon-docs/dist/frameworks/html/config.js-generated-other-entry.js ./node_modules/@storybook/addon-links/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-actions/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-actions/dist/preset/addArgs.js-generated-other-entry.js ./node_modules/@storybook/addon-backgrounds/dist/preset/addDecorator.js-generated-other-entry.js ./node_modules/@storybook/addon-backgrounds/dist/preset/addParameter.js-generated-other-entry.js ./node_modules/@storybook/addon-knobs/dist/preset/addDecorator.js-generated-other-entry.js ./.storybook/preview.js-generated-config-entry.js ./.storybook/generated-stories-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined
```