### PR TITLE
chore: rename 'master' branch to 'main'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Then, display a map by inserting in your page:
 ```
  <map-component></map-component>
 ```
-Angular sample of use is given in ```map/map.components.ts``` (and not included by npm) to display/refresh map elements, using javascript **IoTMapManager** class methods (see [src/iotMapManager/readme.md](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/src/iotMapManager/readme.md)).
+Angular sample of use is given in ```map/map.components.ts``` (and not included by npm) to display/refresh map elements, using javascript **IoTMapManager** class methods (see [src/iotMapManager/readme.md](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/src/iotMapManager/readme.md)).
 
 ## Storybook
 

--- a/src/iotMapManager/css/map.css
+++ b/src/iotMapManager/css/map.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/markers.css
+++ b/src/iotMapManager/css/markers.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/popup.css
+++ b/src/iotMapManager/css/popup.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/shadows.css
+++ b/src/iotMapManager/css/shadows.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/tabs.css
+++ b/src/iotMapManager/css/tabs.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/import_png.d.ts
+++ b/src/iotMapManager/import_png.d.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/index.ts
+++ b/src/iotMapManager/index.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/iot-map-manager.css
+++ b/src/iotMapManager/iot-map-manager.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-area-manager.ts
+++ b/src/iotMapManager/src/iot-map-area-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-area.ts
+++ b/src/iotMapManager/src/iot-map-area.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-cluster-manager.ts
+++ b/src/iotMapManager/src/iot-map-cluster-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-cluster.ts
+++ b/src/iotMapManager/src/iot-map-cluster.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-common-svg.ts
+++ b/src/iotMapManager/src/iot-map-common-svg.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-config.ts
+++ b/src/iotMapManager/src/iot-map-config.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-icons.ts
+++ b/src/iotMapManager/src/iot-map-icons.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-manager.ts
+++ b/src/iotMapManager/src/iot-map-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-marker-manager.ts
+++ b/src/iotMapManager/src/iot-map-marker-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-marker.ts
+++ b/src/iotMapManager/src/iot-map-marker.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-path-manager.ts
+++ b/src/iotMapManager/src/iot-map-path-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-path.ts
+++ b/src/iotMapManager/src/iot-map-path.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-types.ts
+++ b/src/iotMapManager/src/iot-map-types.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-user-marker-manager.ts
+++ b/src/iotMapManager/src/iot-map-user-marker-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-user-marker.ts
+++ b/src/iotMapManager/src/iot-map-user-marker.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau


### PR DESCRIPTION
Fixes #83 

- [x] Replace all `master` references by `main`
- [ ] Modify this PR based on https://github.com/Orange-OpenSource/IOT-Map-Component/pull/108 new files

At the same time after the review:
- [ ] Create the `main` branch with something like https://stevenmortimer.com/5-steps-to-change-github-default-branch-from-master-to-main/
- [ ] Change the `master` into `main` in the project settings
- [ ] Verify that the PRs whose target was `master` are automatically updated

Then:
- [ ] Merge me!
- [ ] Modify the Wiki
- [ ] Remove the `master` branch