### PR TITLE
chore: bump caniuse-lite from 1.0.30001204 to 1.0.30001332

### DIFF
--- a/src/iotMapManager/package-lock.json
+++ b/src/iotMapManager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iotmapmanager",
-  "version": "2.3.0",
+  "version": "2.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -755,9 +755,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
While running `npm i` in `src/iotMapManager` got the following message:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

Results of the update:
```
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001332
Installed version:  1.0.30001204
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite
npm WARN leaflet.markercluster@1.4.1 requires a peer of leaflet@~1.3.1 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.13 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite
npm WARN leaflet.markercluster@1.4.1 requires a peer of leaflet@~1.3.1 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.13 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

caniuse-lite has been successfully updated

Target browser changes:
- and_chr 89
+ and_chr 100
- and_ff 86
+ and_ff 99
- android 89
+ android 100
- chrome 89
- chrome 88
- chrome 87
+ chrome 100
+ chrome 99
+ chrome 98
+ chrome 97
- edge 89
- edge 88
+ edge 100
+ edge 99
+ edge 98
- firefox 86
- firefox 85
+ firefox 99
+ firefox 98
+ firefox 97
- ios_saf 14.0-14.5
- ios_saf 13.4-13.7
+ ios_saf 15.4
+ ios_saf 15.2-15.3
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 14.0-14.4
+ ios_saf 12.2-12.5
- op_mob 62
+ op_mob 64
- opera 73
- opera 72
+ opera 83
+ opera 82
- safari 14
- safari 13.1
+ safari 15.4
+ safari 15.2-15.3
+ safari 14.1
- samsung 13.0
- samsung 12.0
+ samsung 16.0
+ samsung 15.0
```

We can observe that the version of `iotmapmanager` has been updated to 2.6.8 (latest version) as well.