### PR TITLE
chore(deps-dev): bump `ods-storybook-theme` from 0.1.0 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19541,9 +19541,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "ods-storybook-theme": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ods-storybook-theme/-/ods-storybook-theme-0.1.0.tgz",
-      "integrity": "sha512-b8eaCq0gXIuPGkntsKTJfxUImlZM4+t6/kQAZjOP8uxsa8zJIvvGSQGMUWsvOL5g4ImEbsHaUvPbYGtkPNTj1Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ods-storybook-theme/-/ods-storybook-theme-1.0.0.tgz",
+      "integrity": "sha512-OZ2raix20UpDJQDPwkEiO0wdCkQajnBzsz1qVnc7YsjR4+dAYF+LYhGMQnbdlX0mwTH67nrIAQPhqTLi7M1EGQ==",
       "dev": true
     },
     "on-finished": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-storybook": "^0.5.6",
     "eslint-plugin-tsdoc": "^0.2.11",
     "eslint-plugin-vue": "^7.5.0",
-    "ods-storybook-theme": "^0.1.0",
+    "ods-storybook-theme": "^1.0.0",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
     "typedoc": "^0.20.28"
   },


### PR DESCRIPTION
### Description

This PR bumps ods-storybook-theme dev dependency from 0.1.0 to 1.0.0 in order to fix the toolbar hover color.

`package-lock.json` being a bit old, I used the following command to bump the dep:

```
npx npm@6.14.17 i ods-storybook-theme@latest --save-dev
```