### PR TITLE
fix(storybook): build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/iotMapManager/**/*.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook",
-    "build-storybook": "build-storybook -o ./docs && mkdir -p docs/assets/img && cp src/iotMapManager/img/* docs/assets/img/",
+    "build-storybook": "cd src/iotMapManager && npm i && npm run build && cd -- && build-storybook -o ./docs && mkdir -p docs/assets/img && cp src/iotMapManager/img/* docs/assets/img/",
     "deploy-storybook": "git add docs && git commit -m 'chore(storybook): deploy' --allow-empty && git subtree split --branch gh-pages --prefix docs && git push origin gh-pages -f && echo 'Storybook successfully deployed'"
   },
   "repository": {


### PR DESCRIPTION
### Description

Latest Storybook build was in failure: see https://github.com/Orange-OpenSource/IOT-Map-Component/actions/runs/7737340873/job/21096148592

Reproduced it locally when `src/IotMapManager/dist` is not present; meaning that the library is not built already when launching the build of Storybook.

This PR adds a pre-step to do that when launching `npm run build-storybook`.