### PR TITLE
chore(deps-dev): bump Node from 12.x to 14.x in `Docs` workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 on:
   push:
     branches:
-      - master-bump-node-14-docs-workflow
+      - master
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - master-bump-node-14-docs-workflow
 
 jobs:
   docs:
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Install dependencies
         run: npm ci
       - name: Build Storybook


### PR DESCRIPTION
### Description

This PR aims to bump the Node version used for `Docs` GH workflow from 12.x to 14.x (version used for the project).