### PR TITLE
fix(lib): compilation from scratch after cloning the project

### DIFF
--- a/src/iotMapManager/package-lock.json
+++ b/src/iotMapManager/package-lock.json
@@ -4255,6 +4255,17 @@
         }
       }
     },
+    "url-loader": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
+      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "mime-types": "^2.1.27",
+        "schema-utils": "^3.0.0"
+      }
+    },
     "url-parse": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",

--- a/src/iotMapManager/package.json
+++ b/src/iotMapManager/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "ts-loader": "^8.1.0",
     "typescript": "^4.2.3",
+    "url-loader": "^4.1.1",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^3.11.2"


### PR DESCRIPTION
When removing `node_modules` dirs:

```
ERROR in ./src/iot-map-icons.ts 23:0-60
Module not found: Error: Can't resolve 'url-loader' in '/Users/ju/IOT-Map-Component/src/iotMapManager'
 @ ./index.ts 22:0-36 22:0-36
```

However, CI doesn't have the issue. So let's dig why... This fix seems to do the trick.