### PR TITLE
chore: change `master` reference to `main`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` in the repository.
+   latest `main` in the repository.
 
 3. **Isolate the problem** &mdash; ideally create a [reduced test
    case](https://css-tricks.com/reduced-test-cases/) and a live example.
@@ -142,11 +142,11 @@ included in the project:
 2. If you cloned a while ago, get the latest changes from upstream:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    ```
 
-3. Create a new topic branch (off the master project development branch) to
+3. Create a new topic branch (off the main project development branch) to
    contain your feature, change, or fix:
 
    ```bash
@@ -155,14 +155,14 @@ included in the project:
 
 4. Commit your changes in logical chunks. Please adhere to these [git commit
    message guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-   or your code is unlikely be merged into the master project. Use Git's
+   or your code is unlikely be merged into the main project. Use Git's
    [interactive rebase](https://help.github.com/articles/about-git-rebase/)
    feature to tidy up your commits before making them public.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
    ```bash
-   git pull [--rebase] upstream master
+   git pull [--rebase] upstream main
    ```
 
 6. Push your topic branch up to your fork:
@@ -172,7 +172,7 @@ included in the project:
    ```
 
 7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/)
-    with a clear title and description against the `master` branch.
+    with a clear title and description against the `main` branch.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owners to
 license your work under the terms of the [MIT License](../LICENSE) (if it

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
           required: true
         - label: I have [validated](https://html5.validator.nu/) any HTML to avoid common problems
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/.github/CONTRIBUTING.md)
           required: true
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
       options:
         - label: I have [searched](https://github.com/Orange-OpenSource/IOT-Map-Component/issues?utf8=%E2%9C%93&q=is%3Aissue) for duplicate or closed feature requests
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/.github/CONTRIBUTING.md)
           required: true
   - type: textarea
     id: proposal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   FORCE_COLOR: 2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   IoT Map Component is a map component, based on <a href="https://leafletjs.com/">Leaflet</a>, to be integrated in computer or mobile web applications developed in Angular or React. It provides Orange branded design and user experience.
   <br>
-  <a href="https://github.com/Orange-OpenSource/IOT-Map-Component/tree/master/src/iotMapManager#readme"><strong>Visit documentation</strong></a>
+  <a href="https://github.com/Orange-OpenSource/IOT-Map-Component/tree/main/src/iotMapManager#readme"><strong>Visit documentation</strong></a>
   <br>
   <br>
   <a href="https://github.com/Orange-OpenSource/IOT-Map-Component/issues/new?assignees=-&labels=bug&template=bug_report.yml&title=Provide+a+general+summary+of+the+issue">Report bug</a>
@@ -88,7 +88,7 @@ Then, display a map by inserting in your page:
 ```
  <map-component></map-component>
 ```
-Angular sample of use is given in ```map/map.components.ts``` (and not included by npm) to display/refresh map elements, using javascript **IoTMapManager** class methods (see [src/iotMapManager/readme.md](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/src/iotMapManager/readme.md)).
+Angular sample of use is given in ```map/map.components.ts``` (and not included by npm) to display/refresh map elements, using javascript **IoTMapManager** class methods (see [src/iotMapManager/readme.md](https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/src/iotMapManager/readme.md)).
 
 ## Storybook
 

--- a/src/iotMapManager/css/map.css
+++ b/src/iotMapManager/css/map.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/markers.css
+++ b/src/iotMapManager/css/markers.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/popup.css
+++ b/src/iotMapManager/css/popup.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/shadows.css
+++ b/src/iotMapManager/css/shadows.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/css/tabs.css
+++ b/src/iotMapManager/css/tabs.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/import_png.d.ts
+++ b/src/iotMapManager/import_png.d.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/index.ts
+++ b/src/iotMapManager/index.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/iot-map-manager.css
+++ b/src/iotMapManager/iot-map-manager.css
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-area-manager.ts
+++ b/src/iotMapManager/src/iot-map-area-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-area.ts
+++ b/src/iotMapManager/src/iot-map-area.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-cluster-manager.ts
+++ b/src/iotMapManager/src/iot-map-cluster-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-cluster.ts
+++ b/src/iotMapManager/src/iot-map-cluster.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-common-svg.ts
+++ b/src/iotMapManager/src/iot-map-common-svg.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-config.ts
+++ b/src/iotMapManager/src/iot-map-config.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-icons.ts
+++ b/src/iotMapManager/src/iot-map-icons.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-manager.ts
+++ b/src/iotMapManager/src/iot-map-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-marker-manager.ts
+++ b/src/iotMapManager/src/iot-map-marker-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-marker.ts
+++ b/src/iotMapManager/src/iot-map-marker.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-path-manager.ts
+++ b/src/iotMapManager/src/iot-map-path-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-path.ts
+++ b/src/iotMapManager/src/iot-map-path.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-types.ts
+++ b/src/iotMapManager/src/iot-map-types.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-user-marker-manager.ts
+++ b/src/iotMapManager/src/iot-map-user-marker-manager.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau

--- a/src/iotMapManager/src/iot-map-user-marker.ts
+++ b/src/iotMapManager/src/iot-map-user-marker.ts
@@ -5,7 +5,7 @@
 * SPDX-License-Identifier: MIT
 *
 * This software is distributed under the MIT License,
-* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/master/LICENSE
+* the text of which is available at https://github.com/Orange-OpenSource/IOT-Map-Component/blob/main/LICENSE
 * or see the "license.txt" file for more details.
 *
 * Author: S. Gateau


### PR DESCRIPTION
### Related issues

Closes #83 

### Description

After having renamed to `master` branch to `main, this PR changes all the references in the project.

